### PR TITLE
fix: 修复执行 rapper swagger 命令时出现常量被修改的错误

### DIFF
--- a/packages/api/src/config/getPrettierConfig.ts
+++ b/packages/api/src/config/getPrettierConfig.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import log from '../log'
 
 // ts-ignore
-const evalTemp = {
+let evalTemp = {
   semi: false,
   singleQuote: true,
   trailingComma: 'all',


### PR DESCRIPTION
修复执行 rapper swagger 命令时出现常量被修改的错误，导致无法生成对应文档的问题
执行`scripts`语句：
```
"rapper": "antm-api  file --path ./src/actions/rapper/types --action true",
"swagger": "antm-api swagger --path ./src/actions/swagger/types --url https://petstore.swagger.io/v2/swagger.json"
```
错误信息：
```
$ yarn swagger
yarn run v1.22.19
$ antm-api swagger --path ./src/actions/swagger/types --url https://petstore.swagger.io/v2/swagger.json
开始获取swagger数据

+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
swagger data                                                    +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 🚀 swagger版本: 2.0                        
+ 🚴‍♀️ 接口模块数: 3                      
+ 🚗 接口数: 14           
+ 🚄 公共类型数: 6  
+ 🐘 执行模块: 所有模块          
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

TypeError: Assignment to constant variable.
    at eval (eval at <anonymous> (/Users/logg/code/temptaro/node_modules/@antmjs/api/src/config/getPrettierConfig.ts:19:7), <anonymous>:1:10)
    at /Users/logg/code/temptaro/node_modules/@antmjs/api/src/config/getPrettierConfig.ts:19:7
    at new Promise (<anonymous>)
    at getPrettierConfig (/Users/logg/code/temptaro/node_modules/@antmjs/api/src/config/getPrettierConfig.ts:15:10)
    at transform (/Users/logg/code/temptaro/node_modules/@antmjs/api/src/swagger/transform.ts:40:43)
    at Command.swagger (/Users/logg/code/temptaro/node_modules/@antmjs/api/src/swagger/index.ts:45:18)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```